### PR TITLE
Fix linux compilation

### DIFF
--- a/include/qVoxFallDialog.h
+++ b/include/qVoxFallDialog.h
@@ -53,10 +53,10 @@ public:
 	//! Returns the max number of threads to use
 	int getMaxThreadCount() const;
 
-	void qVoxFallDialog::loadParamsFromPersistentSettings();
-	void qVoxFallDialog::loadParamsFrom(const QSettings& settings);
-	void qVoxFallDialog::saveParamsToPersistentSettings();
-	void qVoxFallDialog::saveParamsTo(QSettings& settings);
+	void loadParamsFromPersistentSettings();
+	void loadParamsFrom(const QSettings& settings);
+	void saveParamsToPersistentSettings();
+	void saveParamsTo(QSettings& settings);
 
 protected:
 

--- a/include/qVoxFallTools.h
+++ b/include/qVoxFallTools.h
@@ -29,6 +29,8 @@
 #include <ccPointCloud.h>
 #include <ccScalarField.h>
 #include <ccBox.h>
+#include <ccGLMatrix.h>
+
 
 #include <unordered_map>
 
@@ -50,13 +52,13 @@ public:
 		const Vector3Tpl<float> Y(-std::sin(zRot), std::cos(zRot), 0);
 		const Vector3Tpl<float> Z(0, 0, 1);
 		const Vector3Tpl<float> Tr(0, 0, 0);
-		matrix = &ccGLMatrix::ccGLMatrix(X, Y, Z, Tr);
+		matrix = new ccGLMatrix(X, Y, Z, Tr);
 
 		const Vector3Tpl<float> rX(std::cos(-zRot), std::sin(-zRot), 0);
 		const Vector3Tpl<float> rY(-std::sin(-zRot), std::cos(-zRot), 0);
 		const Vector3Tpl<float> rZ(0, 0, 1);
 		const Vector3Tpl<float> rTr(0, 0, 0);
-		inverse = &ccGLMatrix::ccGLMatrix(rX, rY, rZ, rTr);
+		inverse = new ccGLMatrix(rX, rY, rZ, rTr);
 	}
 
 	static ccBox* CreateVoxelMesh(CCVector3 V, float voxelSize, int voxelIdx);

--- a/include/qVoxFallTools.h
+++ b/include/qVoxFallTools.h
@@ -41,8 +41,8 @@ class qVoxFallTransform
 	float zRot;
 
 public:
-	ccGLMatrix* matrix;
-	ccGLMatrix* inverse;
+	ccGLMatrix matrix;
+	ccGLMatrix inverse;
 	qVoxFallTransform(double azimuth)
 	{
 		az = azimuth;
@@ -52,13 +52,13 @@ public:
 		const Vector3Tpl<float> Y(-std::sin(zRot), std::cos(zRot), 0);
 		const Vector3Tpl<float> Z(0, 0, 1);
 		const Vector3Tpl<float> Tr(0, 0, 0);
-		matrix = new ccGLMatrix(X, Y, Z, Tr);
+		matrix = ccGLMatrix(X, Y, Z, Tr);
 
 		const Vector3Tpl<float> rX(std::cos(-zRot), std::sin(-zRot), 0);
 		const Vector3Tpl<float> rY(-std::sin(-zRot), std::cos(-zRot), 0);
 		const Vector3Tpl<float> rZ(0, 0, 1);
 		const Vector3Tpl<float> rTr(0, 0, 0);
-		inverse = new ccGLMatrix(rX, rY, rZ, rTr);
+		inverse = ccGLMatrix(rX, rY, rZ, rTr);
 	}
 
 	static ccBox* CreateVoxelMesh(CCVector3 V, float voxelSize, int voxelIdx);

--- a/src/qVoxFallProcess.cpp
+++ b/src/qVoxFallProcess.cpp
@@ -408,8 +408,8 @@ bool qVoxFallProcess::Compute(const qVoxFallDialog& dlg, QString& errorMessage, 
 	mesh->merge(mesh2, false);
 
 	auto transform = qVoxFallTransform(azimuth);
-	mesh->applyGLTransformation_recursive(transform.matrix);
-	mesh1->applyGLTransformation_recursive(transform.matrix);
+	mesh->applyGLTransformation_recursive(&transform.matrix);
+	mesh1->applyGLTransformation_recursive(&transform.matrix);
 
 	mesh1->setEnabled(false);
 
@@ -684,7 +684,7 @@ bool qVoxFallProcess::Compute(const qVoxFallDialog& dlg, QString& errorMessage, 
 			}
 			indices.clear();
 		}
-		ccGroup->applyGLTransformation_recursive(transform.inverse);
+		ccGroup->applyGLTransformation_recursive(&transform.inverse);
 		ccGroup->setVisible(true);
 		app->addToDB(ccGroup);
 
@@ -733,8 +733,8 @@ bool qVoxFallProcess::Compute(const qVoxFallDialog& dlg, QString& errorMessage, 
 	}
 
 	//prepare export cloud
-	mesh1->applyGLTransformation_recursive(transform.inverse);
-	s_VoxFallParams.voxfall->applyGLTransformation_recursive(transform.inverse);
+	mesh1->applyGLTransformation_recursive(&transform.inverse);
+	s_VoxFallParams.voxfall->applyGLTransformation_recursive(&transform.inverse);
 	sfIdx = s_VoxFallParams.voxfall->getScalarFieldIndexByName(CLUSTER_SF_NAME);
 	s_VoxFallParams.voxfall->setCurrentDisplayedScalarField(sfIdx);;
 	s_VoxFallParams.voxfall->showSF(true);

--- a/src/qVoxFallTools.cpp
+++ b/src/qVoxFallTools.cpp
@@ -67,9 +67,9 @@ ccBox* qVoxFallTransform::CreateVoxelMesh(CCVector3 V, float voxelSize, int voxe
 	const Vector3Tpl<float> X(1, 0, 0);
 	const Vector3Tpl<float> Y(0, 1, 0);
 	const Vector3Tpl<float> Z(0, 0, 1);
-	ccGLMatrix* matrix = new ccGLMatrix(X, Y, Z, V);
+	const ccGLMatrix matrix(X, Y, Z, V);
 
-	ccBox* voxel = new ccBox(dims, matrix, name);
+	ccBox* voxel = new ccBox(dims, &matrix, name);
 	voxel->computePerTriangleNormals();
 	return voxel;
 }

--- a/src/qVoxFallTools.cpp
+++ b/src/qVoxFallTools.cpp
@@ -67,7 +67,7 @@ ccBox* qVoxFallTransform::CreateVoxelMesh(CCVector3 V, float voxelSize, int voxe
 	const Vector3Tpl<float> X(1, 0, 0);
 	const Vector3Tpl<float> Y(0, 1, 0);
 	const Vector3Tpl<float> Z(0, 0, 1);
-	ccGLMatrix* matrix = &ccGLMatrix::ccGLMatrix(X, Y, Z, V);
+	ccGLMatrix* matrix = new ccGLMatrix(X, Y, Z, V);
 
 	ccBox* voxel = new ccBox(dims, matrix, name);
 	voxel->computePerTriangleNormals();


### PR DESCRIPTION
Hi,
cc @dgirardeau 
Just a PR to fix Linux compilation. I did not made a full review of the code but just tried to make the code compile on Linux.
I think it makes code more corrects on some aspects. 

For the details, `break` inside an openMP loop is not correct (even if allowed by MSVC but the [doc itself says it's not correct)](https://learn.microsoft.com/en-us/cpp/parallel/concrt/convert-an-openmp-loop-that-uses-cancellation?view=msvc-170). Also assigning your `error` bool inside a parallel loop could leads to a race condition. I use an atomic but it could be an openMP `critical section`.